### PR TITLE
Fix typo in nova-lxd Ansible

### DIFF
--- a/source/technical/nova-lxd/nova-lxd-ansible.md
+++ b/source/technical/nova-lxd/nova-lxd-ansible.md
@@ -39,7 +39,7 @@ This installation takes rather long time (totally around ~2h according to disk p
     # scripts/bootstrap-ansible.sh
 ```
 
-6. Default scenario is without CEPH. Select CEPH scenario if you want and bootstrap AOI  (about 6min in the test)
+6. Default scenario is without CEPH. Select CEPH scenario if you want and bootstrap AIO  (about 6min in the test)
 ```
     # export SCENARIO='ceph'
     # scripts/bootstrap-aio.sh


### PR DESCRIPTION
The typo is AOI instead of AIO (Asynchronous I/O) in https://docs.deep-hybrid-datacloud.eu/en/user-docs/technical/nova-lxd/nova-lxd-ansible.html